### PR TITLE
feat: Add room assignment when calling start game endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.elliott</groupId>
 	<artifactId>two-rooms-and-a-boom</artifactId>
-	<version>0.1.0</version>
+	<version>1.0.0</version>
 	<name>TwoRoomsAndABoom</name>
 	<description>Java SpringBoot application used to run the backend of instance of the card game Two Rooms and a Boom by Alan Gerding and Sean Mccoy</description>
 	<properties>

--- a/src/main/java/com/elliott/tworoomsandaboom/controller/game/GameController.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/controller/game/GameController.java
@@ -93,6 +93,17 @@ public class GameController {
         return ResponseEntity.ok().body("");
     }
 
+    @GetMapping("/room")
+    public ResponseEntity<Room> getRoom(
+            @RequestParam("playerId")
+            int playerId
+    )
+    {
+        log.info("Get Room: {}", playerId);
+        Room room = gameDAO.getRoom(playerId);
+        return ResponseEntity.ok().body(room);
+    }
+
     @GetMapping("/endGame")
     public ResponseEntity<String> endGame()
     {

--- a/src/main/java/com/elliott/tworoomsandaboom/controller/game/GameController.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/controller/game/GameController.java
@@ -7,6 +7,8 @@ import com.elliott.tworoomsandaboom.card.Card;
 import com.elliott.tworoomsandaboom.dao.game.GameDAO;
 import com.elliott.tworoomsandaboom.game.GameOperations;
 import com.elliott.tworoomsandaboom.dao.player.PlayerDAO;
+import com.elliott.tworoomsandaboom.game.Room;
+import com.elliott.tworoomsandaboom.player.AssignedPlayer;
 import com.elliott.tworoomsandaboom.player.Player;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -67,16 +70,27 @@ public class GameController {
         return ResponseEntity.status(HttpStatus.OK).body("");
     }
 
-    @GetMapping("/assignCards")
-    public ResponseEntity<Map<Player, Card>> assignCards()
+    @GetMapping("/startGame")
+    public ResponseEntity<String> startGame()
     {
+        log.info("Starting new Game");
         Player[] players = playerDAO.getPlayers();
         BasicCards basicCards = gameDAO.getBasicCards();
         List<Card> activeCards = gameDAO.getActiveCards();
         Map<Player, Card> assignedCards = gameOperations.dealCards(players, basicCards, activeCards);
-        log.info("Assigned cards: {}", assignedCards);
-        gameDAO.saveAssignedCards(assignedCards);
-        return ResponseEntity.ok(assignedCards);
+        Map<Player, Room> assignedRooms = gameOperations.assignRooms(players);
+        List<AssignedPlayer> assignedPlayers = new ArrayList<>();
+        Arrays.stream(players).forEach(
+            player -> assignedPlayers.add(
+                new AssignedPlayer(
+                    player,
+                    assignedCards.get(player),
+                    assignedRooms.get(player)
+                )
+            )
+        );
+        gameDAO.saveAssignedPlayers(assignedPlayers);
+        return ResponseEntity.ok().body("");
     }
 
     @GetMapping("/endGame")

--- a/src/main/java/com/elliott/tworoomsandaboom/dao/game/GameDAO.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/dao/game/GameDAO.java
@@ -3,7 +3,7 @@ package com.elliott.tworoomsandaboom.dao.game;
 import com.elliott.tworoomsandaboom.card.*;
 import com.elliott.tworoomsandaboom.db.DatabaseConnectionManager;
 import com.elliott.tworoomsandaboom.error.DatabaseException;
-import com.elliott.tworoomsandaboom.player.Player;
+import com.elliott.tworoomsandaboom.player.AssignedPlayer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -22,7 +22,7 @@ public class GameDAO {
     private static final String SET_ACTIVE_CARDS_BY_TITLE = "UPDATE card SET isActive = 1 WHERE cardTitle IN (%s);";
     private static final String SET_ACTIVE_CARDS_BY_ID = "UPDATE card SET isActive = 1 WHERE cardId IN (%s);";
     private static final String RESET_ACTIVE_CARDS = "UPDATE card SET isActive = 0 WHERE isActive = 1 AND isBasic = 0;";
-    private static final String ADD_ASSIGNED_CARDS = "INSERT INTO game (playerId, cardId) VALUES %s;";
+    private static final String ADD_ASSIGNED_PLAYERS = "INSERT INTO game (playerId, cardId, room) VALUES %s;";
     private static final String CLEAR_ASSIGNED_CARDS = "DELETE FROM game";
     private static final String GET_ACTIVE_CARDS = "SELECT cardId, teamId, cardTitle FROM card WHERE isActive = 1 AND isBasic = 0;";
     private static final String GET_BASIC_CARDS = "SELECT cardId, teamId, cardTitle FROM card WHERE isActive = 1 AND isBasic = 1;";
@@ -146,26 +146,20 @@ public class GameDAO {
         }
     }
 
-    public void saveAssignedCards(Map<Player, Card> assignedCards)
-    {
+    public void saveAssignedPlayers(List<AssignedPlayer> assignedPlayers) {
         this.clearAssignedCards();
 
-        StringBuilder assignedCardIds = new StringBuilder();
-        for (Map.Entry<Player, Card> assignedCard : assignedCards.entrySet())
-        {
-            assignedCardIds.append("(")
-                    .append(assignedCard.getKey().getPlayerId())
-                    .append(", ")
-                    .append(assignedCard.getValue().getCardId())
-                    .append("),");
+        StringBuilder assignedPlayerStrings = new StringBuilder();
+        for (AssignedPlayer assignedPlayer : assignedPlayers) {
+            assignedPlayerStrings.append(assignedPlayer.toDatabaseInputString()).append(',');
         }
-        log.info(assignedCardIds.substring(0, assignedCardIds.length()-1));
-        String addAssignedCardsFormatted = String.format(ADD_ASSIGNED_CARDS, assignedCardIds.substring(0, assignedCardIds.length()-1));
+        String addAssignedPlayersFormatted =
+            String.format(ADD_ASSIGNED_PLAYERS, assignedPlayerStrings.substring(0, assignedPlayerStrings.length()-1));
         try (Connection connection = databaseConnectionManager.getConnection();
-             PreparedStatement statement = connection.prepareStatement(addAssignedCardsFormatted))
+             PreparedStatement statement = connection.prepareStatement(addAssignedPlayersFormatted))
         {
             statement.execute();
-            log.info("!GAME CARDS HAVE BEEN ASSIGNED!");
+            log.info("!PLAYERS HAVE BEEN ASSIGNED A CARD AND A STARTING ROOM!");
         }
         catch (SQLException e)
         {

--- a/src/main/java/com/elliott/tworoomsandaboom/dao/game/GameDAO.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/dao/game/GameDAO.java
@@ -14,7 +14,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component

--- a/src/main/java/com/elliott/tworoomsandaboom/game/GameOperations.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/game/GameOperations.java
@@ -60,4 +60,18 @@ public class GameOperations
         }
         return assignedCards;
     }
+
+    public Map<Player, Room> assignRooms(Player[] players) {
+        List<Player> unassignedPlayers = new ArrayList<>(List.of(players));
+        ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
+        Map<Player, Room> assignedRooms = new LinkedHashMap<>();
+
+        for (int playerIt = 0; playerIt < players.length; playerIt++)
+        {
+            int playerIndex = threadLocalRandom.nextInt(0, unassignedPlayers.size());
+            Room room = playerIt % 2 == 0 ? Room.A : Room.B;
+            assignedRooms.put(unassignedPlayers.remove(playerIndex), room);
+        }
+        return assignedRooms;
+    }
 }

--- a/src/main/java/com/elliott/tworoomsandaboom/game/Room.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/game/Room.java
@@ -1,0 +1,11 @@
+package com.elliott.tworoomsandaboom.game;
+
+public enum Room {
+    A('A'), B('B');
+
+    Room(char room) {
+        this.room = room;
+    }
+
+    public final char room;
+}

--- a/src/main/java/com/elliott/tworoomsandaboom/player/AssignedPlayer.java
+++ b/src/main/java/com/elliott/tworoomsandaboom/player/AssignedPlayer.java
@@ -1,0 +1,38 @@
+package com.elliott.tworoomsandaboom.player;
+
+import com.elliott.tworoomsandaboom.card.Card;
+import com.elliott.tworoomsandaboom.game.Room;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AssignedPlayer {
+    private Player player;
+    private Card card;
+    private Room room;
+
+    public String toDatabaseInputString()
+    {
+        return String.format("(%d,%d,'%s')",
+                this.player.getPlayerId(),
+                this.card.getCardId(),
+                this.room.toString()
+        );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("(%d)%s[card: %s, room: %s]",
+                this.player.getPlayerId(),
+                this.player.getUsername(),
+                this.card.getTitle(),
+                this.room.name()
+        );
+    }
+}

--- a/src/main/resources/sql/deployTables.sql
+++ b/src/main/resources/sql/deployTables.sql
@@ -31,6 +31,7 @@ CREATE TABLE `two_rooms_and_a_boom`.`game` (
     `gameId` INT NOT NULL AUTO_INCREMENT,
     `playerId` INT NOT NULL,
     `cardId` INT NOT NULL,
+    `room` ENUM('A', 'B') NOT NULL,
     PRIMARY KEY (`gameId`),
     INDEX `player_idx` (`playerId` ASC) VISIBLE,
     INDEX `card_idx` (`cardId` ASC) VISIBLE,

--- a/src/test/java/com/elliott/tworoomsandaboom/controller/game/GameControllerTest.java
+++ b/src/test/java/com/elliott/tworoomsandaboom/controller/game/GameControllerTest.java
@@ -19,11 +19,8 @@ import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/elliott/tworoomsandaboom/controller/game/GameControllerTest.java
+++ b/src/test/java/com/elliott/tworoomsandaboom/controller/game/GameControllerTest.java
@@ -62,7 +62,7 @@ public class GameControllerTest {
     }
 
     @Test
-    void shouldReturnOkStatusAndAssignedCardsOnAssignCardsEndpoint()
+    void shouldReturnOkStatusOnStartGameEndpoint()
     {
         Player[] players = new Player[]{
                 new Player(1, "testPlayer1"),
@@ -84,15 +84,7 @@ public class GameControllerTest {
         when(gameDaoMock.getBasicCards()).thenReturn(basicCards);
         when(gameDaoMock.getActiveCards()).thenReturn(new ArrayList<>());
 
-        ResponseEntity<Map<Player, Card>> response = gameController.assignCards();
+        ResponseEntity<String> response = gameController.startGame();
         assertEquals(HttpStatus.OK, response.getStatusCode());
-
-        Map<Player, Card> assignedCards = response.getBody();
-        assertEquals(6, assignedCards.size());
-        assertTrue(assignedCards.containsValue(CardConstants.PRESIDENT_CARD));
-        assertTrue(assignedCards.containsValue(CardConstants.BOMBER_CARD));
-        assertTrue(assignedCards.containsValue(CardConstants.RED_TEAM_CARD));
-        assertTrue(assignedCards.containsValue(CardConstants.BLUE_TEAM_CARD));
-        assertFalse(assignedCards.containsValue(CardConstants.GAMBLER_CARD));
     }
 }

--- a/src/test/java/com/elliott/tworoomsandaboom/controller/game/GameControllerTest.java
+++ b/src/test/java/com/elliott/tworoomsandaboom/controller/game/GameControllerTest.java
@@ -7,6 +7,7 @@ import com.elliott.tworoomsandaboom.card.Card;
 import com.elliott.tworoomsandaboom.dao.game.GameDAO;
 import com.elliott.tworoomsandaboom.dao.player.PlayerDAO;
 import com.elliott.tworoomsandaboom.game.GameOperations;
+import com.elliott.tworoomsandaboom.game.Room;
 import com.elliott.tworoomsandaboom.player.Player;
 import com.elliott.tworoomsandaboom.util.CardConstants;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,5 +84,15 @@ public class GameControllerTest {
 
         ResponseEntity<String> response = gameController.startGame();
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void shouldReturnOkStatusAndRoomOnGetRoomEndpoint()
+    {
+        when(gameDaoMock.getRoom(123)).thenReturn(Room.A);
+
+        ResponseEntity<Room> response = gameController.getRoom(123);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Room.A, response.getBody());
     }
 }

--- a/src/test/java/com/elliott/tworoomsandaboom/game/GameOperationsTest.java
+++ b/src/test/java/com/elliott/tworoomsandaboom/game/GameOperationsTest.java
@@ -198,6 +198,47 @@ class GameOperationsTest
         assertThrows(GameRuleException.class, () -> gameOperations.dealCards(players, basicCards, activeCards));
     }
 
+    @Test
+    void shouldAssignPlayersToRoomsEquallyWhenEvenNumberOfPlayers()
+    {
+        Player[] players = new Player[] {
+                new Player(1, "testPlayer1"),
+                new Player(2, "testPlayer2"),
+                new Player(3, "testPlayer3"),
+                new Player(4, "testPlayer4"),
+                new Player(5, "testPlayer5"),
+                new Player(6, "testPlayer6")
+        };
+
+        Map<Player, Room> assignedRooms = gameOperations.assignRooms(players);
+        int countRoomA = assignedRooms.values().stream().filter(room -> room.equals(Room.A)).toList().size();
+        int countRoomB = assignedRooms.values().stream().filter(room -> room.equals(Room.B)).toList().size();
+
+        assertEquals(3, countRoomA);
+        assertEquals(3, countRoomB);
+    }
+
+    @Test
+    void shouldAssignPlayersToRoomsOneExtraInAWhenOddNumberOfPlayers()
+    {
+        Player[] players = new Player[] {
+                new Player(1, "testPlayer1"),
+                new Player(2, "testPlayer2"),
+                new Player(3, "testPlayer3"),
+                new Player(4, "testPlayer4"),
+                new Player(5, "testPlayer5"),
+                new Player(6, "testPlayer6"),
+                new Player(7, "testPlayer7")
+        };
+
+        Map<Player, Room> assignedRooms = gameOperations.assignRooms(players);
+        int countRoomA = assignedRooms.values().stream().filter(room -> room.equals(Room.A)).toList().size();
+        int countRoomB = assignedRooms.values().stream().filter(room -> room.equals(Room.B)).toList().size();
+
+        assertEquals(4, countRoomA);
+        assertEquals(3, countRoomB);
+    }
+
     private long countCards(Map<Player, Card> assignedCards, Card card)
     {
         return assignedCards.entrySet()


### PR DESCRIPTION
Removed endpoint to assign cards and replaced with a start game endpoint which will assign a card and a starting room to each player